### PR TITLE
refactor endpoints: las validaciones al servicio, para separar lógica

### DIFF
--- a/Application/Interfaces/ICivilizationService.cs
+++ b/Application/Interfaces/ICivilizationService.cs
@@ -1,22 +1,19 @@
 ﻿using Application.Models.Dto;
 using Application.Models.Request;
 using Domain.Entities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Domain.Interfaces;
-using Domain.Enums;
 
 namespace Application.Interfaces
 {
     public interface ICivilizationService
     {
         Task<IEnumerable<CivilizationGalleryDto>> GetAllCivilization(CancellationToken ct);
+
         Task<CivilizationDetailDto?> GetCivizlizationById(int id, CancellationToken ct);
+
         Task<Civilization> CreateCivilization(CreateCivilizationRequest request, CancellationToken ct);
-        Task UpdateCivilization(int id, UpdateCivilizationRequest request, CancellationToken ct);
-        Task DeleteCivilization(int id, CancellationToken ct);
+
+        Task<bool> UpdateCivilization(int id, UpdateCivilizationRequest request, CancellationToken ct);
+
+        Task<bool> DeleteCivilization(int id, CancellationToken ct);
     }
 }

--- a/Application/Models/Request/CivilizationRequest.cs
+++ b/Application/Models/Request/CivilizationRequest.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel.DataAnnotations;
 using Domain.Entities;
 using Domain.Enums;
 
@@ -30,16 +24,19 @@ namespace Application.Models.Request
             };
         }
     }
+
     public class UpdateCivilizationRequest
     {
         [RegularExpression(@"^(?!\s*$).+", ErrorMessage = "El campo Nombre no puede contener solo espacios.")]
         [MinLength(10, ErrorMessage = "El campo Nombre debe tener al menos 10 caracteres.")]
         public string? Name { get; set; }
+
         public string? Summary { get; set; }
         public string? Overview { get; set; }
         public string? ImageUrl { get; set; }
         public TerritoryType? Territory { get; set; }
         public CivilizationState? State { get; set; }
+
         public static void ApplyToEntity(UpdateCivilizationRequest req, Civilization civilization)
         {
             if (req.Name is not null) civilization.Name = req.Name;
@@ -51,4 +48,3 @@ namespace Application.Models.Request
         }
     }
 }
-

--- a/Application/Services/CivilizationService.cs
+++ b/Application/Services/CivilizationService.cs
@@ -1,25 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Application.Interfaces;
+﻿using Application.Interfaces;
 using Application.Models.Dto;
 using Application.Models.Request;
 using Domain.Entities;
-using Domain.Enums;
 using Domain.Interfaces;
-using Infrastructure.Repositories;
-using Microsoft.EntityFrameworkCore;
-using static Application.Models.Dto.BattleTableDto;
-
-
 
 namespace Application.Services
 {
     public class CivilizationService : ICivilizationService
     {
         private readonly ICivilizationRepository _civilizationRepository;
+
         public CivilizationService(ICivilizationRepository civilizationRepository)
         {
             _civilizationRepository = civilizationRepository;
@@ -38,21 +28,35 @@ namespace Application.Services
         }
 
         public async Task<Civilization> CreateCivilization(CreateCivilizationRequest request, CancellationToken ct)
+
         {
             var civilization = CreateCivilizationRequest.ToEntity(request);
             return await _civilizationRepository.CreateCivilization(civilization, ct);
         }
 
-
-        public async Task UpdateCivilization(int id, UpdateCivilizationRequest request, CancellationToken ct)
+        public async Task<bool> UpdateCivilization(int id, UpdateCivilizationRequest request, CancellationToken ct)
         {
             var civilization = await _civilizationRepository.GetCivizlizationById(id, ct);
-             await _civilizationRepository.UpdateCivilization(civilization, ct);
+            if (civilization is null)
+            {
+                return false;
+            }
+            UpdateCivilizationRequest.ApplyToEntity(request, civilization);
+            await _civilizationRepository.UpdateCivilization(civilization, ct);
+            return true;
         }
-        public async Task DeleteCivilization(int id, CancellationToken ct)
+
+        public async Task<bool> DeleteCivilization(int id, CancellationToken ct)
         {
             var civilization = await _civilizationRepository.GetCivizlizationById(id, ct);
-             await _civilizationRepository.DeleteCivilization(civilization, ct);
+            if (civilization is null)
+            {
+                return false;
+            }
+
+            await _civilizationRepository.DeleteCivilization(civilization, ct);
+
+            return true;
         }
     }
 }

--- a/Domain/Interfaces/ICivilizationRepository.cs
+++ b/Domain/Interfaces/ICivilizationRepository.cs
@@ -1,18 +1,17 @@
 ﻿using Domain.Entities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Domain.Interfaces
 {
     public interface ICivilizationRepository
     {
         Task<IEnumerable<Civilization>> GetAllCivilization(CancellationToken ct);
+
         Task<Civilization?> GetCivizlizationById(int id, CancellationToken ct);
+
         Task<Civilization> CreateCivilization(Civilization civilization, CancellationToken ct);
+
         Task UpdateCivilization(Civilization civilization, CancellationToken ct);
+
         Task DeleteCivilization(Civilization civilization, CancellationToken ct);
     }
 }

--- a/Infrastructure/Repositories/BatlleRepository.cs
+++ b/Infrastructure/Repositories/BatlleRepository.cs
@@ -1,18 +1,13 @@
 ﻿using Domain.Entities;
 using Domain.Interfaces;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 
 namespace Infrastructure.Repositories
 {
     public class BatlleRepository : IBattleRepository
     {
         private readonly ApplicationContext _context;
+
         public BatlleRepository(ApplicationContext context)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
@@ -26,7 +21,6 @@ namespace Infrastructure.Repositories
                 .ThenInclude(cb => cb.Civilization)
             .OrderBy(b => b.Name)
             .ToListAsync(ct);
-            
         }
 
         public async Task<Battle?> GetByIdAsync(int id, CancellationToken ct)

--- a/Infrastructure/Repositories/CivilizationRepository.cs
+++ b/Infrastructure/Repositories/CivilizationRepository.cs
@@ -1,11 +1,6 @@
 ﻿using Domain.Entities;
 using Domain.Interfaces;
 using Microsoft.EntityFrameworkCore;//Mirar usings
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Infrastructure.Repositories
 {
@@ -30,7 +25,6 @@ namespace Infrastructure.Repositories
                 .FirstOrDefaultAsync(c => c.Id == id, ct);
         }
 
-
         public async Task<Civilization> CreateCivilization(Civilization civilization, CancellationToken ct)
         {
             await _context.Civilizations.AddAsync(civilization);
@@ -49,4 +43,4 @@ namespace Infrastructure.Repositories
             await _context.SaveChangesAsync(ct);
         }
     }
-    }
+}


### PR DESCRIPTION
La salida final de status code HTTP queda asi:

### Tabla de Respuestas del `CivilizationController`

| Endpoint | Respuesta Exitosa (2xx) | Respuesta "No Encontrado" (404) | Respuesta de Error (500) |
| :--- | :--- | :--- | :--- |
| **`GET /api/civilizations`** | **`200 OK`** <br> Devuelve un array de `CivilizationGalleryDto`. | **No Aplica** | **`500 Internal Server Error`** <br> Mensaje: "Ocurrio un error..., ex.Message" |
| **`GET /api/civilizations/{id}`** | **`200 OK`** <br> Devuelve el `CivilizationDetailDto` solicitado. | **`404 Not Found`** <br> Mensaje: "No se encontró la Civilización con id {id}" | **`500 Internal Server Error`** <br> Mensaje: "Ocurrio un error..., ex.Message" |
| **`POST /api/civilizations`** | **`200 OK`** <br> Devuelve el objeto de la civilización creada. | **No Aplica** | **`500 Internal Server Error`** <br> Mensaje: "Ocurrio un error..., ex.Message" |
| **`PUT /api/civilizations/{id}`** | **`204 No Content`** <br> Cuerpo de la respuesta vacío. | **`404 Not Found`** <br> Mensaje: "No se encontró la civilización con id {id}" | **`500 Internal Server Error`** <br> Mensaje: "Ocurrio un error..., ex.Message" |
| **`DELETE /api/civilizations/{id}`**| **`204 No Content`** <br> Cuerpo de la respuesta vacío. | **`404 Not Found`** <br> Mensaje: "No se encontró la civilización con id {id}" | **`500 Internal Server Error`** <br> Mensaje: "Ocurrió un error..., ex.Message" |